### PR TITLE
Add option for overriding of device ID

### DIFF
--- a/pvr.sledovanitv.cz/addon.xml.in
+++ b/pvr.sledovanitv.cz/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.sledovanitv.cz"
-  version="2.0.1"
+  version="2.1.0"
   name="PVR Client for sledovanitv.cz (unofficial)"
   provider-name="palinek">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.sledovanitv.cz/resources/language/resource.language.cs_cz/strings.po
+++ b/pvr.sledovanitv.cz/resources/language/resource.language.cs_cz/strings.po
@@ -30,6 +30,10 @@ msgctxt "#30001"
 msgid "Password"
 msgstr "Heslo"
 
+msgctxt "#30008"
+msgid "Device ID (empty - use MAC address)"
+msgstr "ID zařízení (prázdné - použít MAC adresu)"
+
 msgctxt "#30002"
 msgid "Stream quality"
 msgstr "Kvalita streamu"

--- a/pvr.sledovanitv.cz/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.sledovanitv.cz/resources/language/resource.language.en_gb/strings.po
@@ -30,6 +30,10 @@ msgctxt "#30001"
 msgid "Password"
 msgstr "Password"
 
+msgctxt "#30008"
+msgid "Device ID (empty - use MAC address)"
+msgstr "Device ID (empty - use MAC address)"
+
 msgctxt "#30002"
 msgid "Stream quality"
 msgstr "Stream quality"

--- a/pvr.sledovanitv.cz/resources/language/resource.language.sk_sk/strings.po
+++ b/pvr.sledovanitv.cz/resources/language/resource.language.sk_sk/strings.po
@@ -30,6 +30,10 @@ msgctxt "#30001"
 msgid "Password"
 msgstr "Heslo"
 
+msgctxt "#30008"
+msgid "Device ID (empty - use MAC address)"
+msgstr "ID zariadenia (prázdne - použiť MAC adresu)"
+
 msgctxt "#30002"
 msgid "Stream quality"
 msgstr "Kvalita streamu"

--- a/pvr.sledovanitv.cz/resources/settings.xml
+++ b/pvr.sledovanitv.cz/resources/settings.xml
@@ -22,6 +22,14 @@
             <hidden>true</hidden>
           </control>
         </setting>
+        <setting id="deviceId" type="string" label="30008">
+          <level>1</level>
+          <default></default>
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
+          <control type="edit" format="string" />
+        </setting>
         <setting id="streamQuality" type="integer" label="30002">
           <level>1</level>
           <default>0</default> <!-- StreamQuality_t::SQ_DEFAULT -->

--- a/src/PVRIptvData.cpp
+++ b/src/PVRIptvData.cpp
@@ -103,7 +103,7 @@ PVRIptvData::PVRIptvData(PVRIptvConfiguration cfg)
   , m_useH265{cfg.useH265}
   , m_useAdaptive{cfg.useAdaptive}
   , m_showLockedChannels{cfg.showLockedChannels}
-  , m_manager{std::move(cfg.userName), std::move(cfg.password)}
+  , m_manager{std::move(cfg.userName), std::move(cfg.password), std::move(cfg.deviceId)}
 {
 
   SetEPGTimeFrame(m_epgMaxDays);

--- a/src/PVRIptvData.h
+++ b/src/PVRIptvData.h
@@ -133,6 +133,7 @@ struct PVRIptvConfiguration
 {
   std::string userName;
   std::string password;
+  std::string deviceId; //!< device identifier (value for overriding the MAC address detection)
   int streamQuality;
   int epgMaxDays;
   unsigned fullChannelEpgRefresh; //!< delay (seconds) between full channel/EPG refresh

--- a/src/apimanager.cpp
+++ b/src/apimanager.cpp
@@ -181,9 +181,12 @@ std::string ApiManager::formatTime(time_t t)
   return buf;
 }
 
-ApiManager::ApiManager(const std::string & userName, const std::string & userPassword)
+ApiManager::ApiManager(const std::string & userName
+    , const std::string & userPassword
+    , const std::string & overridenMac)
   : m_userName{userName}
   , m_userPassword{userPassword}
+  , m_overridenMac{overridenMac}
   , m_sessionId{std::make_shared<std::string>()}
 {
   XBMC->Log(LOG_NOTICE, "Loading ApiManager");
@@ -264,7 +267,7 @@ bool ApiManager::pairDevice()
     char hostName[256];
     gethostname(hostName, 256);
 
-    std::string macAddr = get_mac_address();
+    std::string macAddr = m_overridenMac.empty() ? get_mac_address() : m_overridenMac;
     if (macAddr.empty())
     {
       XBMC->Log(LOG_NOTICE, "Unable to get MAC address, using a dummy for serial");

--- a/src/apimanager.h
+++ b/src/apimanager.h
@@ -51,7 +51,9 @@ public:
   static std::string formatTime(time_t t);
 
 public:
-  ApiManager(const std::string & userName, const std::string & userPassword);
+  ApiManager(const std::string & userName
+      , const std::string & userPassword
+      , const std::string & overridenMac);
 
   bool pairDevice();
   bool login();
@@ -85,6 +87,7 @@ private:
   static const std::string PAIR_FILE;
   const std::string m_userName;
   const std::string m_userPassword;
+  const std::string m_overridenMac;
   std::string m_deviceId;
   std::string m_password;
   std::shared_ptr<const std::string> m_sessionId;

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -100,6 +100,11 @@ static void ReadSettings(PVRIptvConfiguration & cfg)
     cfg.password = buffer;
   }
 
+  if (XBMC->GetSetting("deviceId", &buffer))
+  {
+    cfg.deviceId = buffer;
+  }
+
   if (!XBMC->GetSetting("streamQuality", &cfg.streamQuality))
   {
     cfg.streamQuality = 0;


### PR DESCRIPTION
If set, addon is not using MAC address detection, but uses the
configured value for "serial".

closes #34