### PR TITLE
[Leia] update CMakeLists.txt to 3.5, change header include and increase version to 1.5.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,39 @@
+# build artifacts
+build/
+pvr.*/addon.xml
+
+# Debian build files
+debian/changelog
+debian/files
+debian/*.log
+debian/*.substvars
+debian/.debhelper/
+debian/tmp/
+debian/kodi-pvr-*/
+obj-x86_64-linux-gnu/
+
+# commonly used editors
+# vim
+*.swp
+
+# Eclipse
+*.project
+*.cproject
+.classpath
+*.sublime-*
+.settings/
+
+# KDevelop 4
+*.kdev4
+
+# Visual Studio
+.vs/
+
+# gedit
+*~
+
+# CLion
+/.idea
+
+# clion
+.idea/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR})
 find_package(Kodi REQUIRED)
 find_package(JsonCpp REQUIRED)
 
-include_directories(${KODI_INCLUDE_DIR}
+include_directories(${KODI_INCLUDE_DIR}/.. # Hack way with "/..", need bigger Kodi cmake rework to match right include ways
                     ${JSONCPP_INCLUDE_DIRS})
 # workaround for windows & unneeded including of p8-platform/windows/dlfcn-win32.h from libXBMC_addon.h
 if(WIN32)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,7 @@
+cmake_minimum_required(VERSION 3.5)
 project(pvr.sledovanitv.cz)
 
-cmake_minimum_required(VERSION 2.6)
-
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR})
-
-enable_language(CXX)
 
 find_package(Kodi REQUIRED)
 find_package(JsonCpp REQUIRED)

--- a/FindJsonCpp.cmake
+++ b/FindJsonCpp.cmake
@@ -1,15 +1,15 @@
 find_package(PkgConfig)
 if(PKG_CONFIG_FOUND)
-  pkg_check_modules (JSONCPP jsoncpp)
+  pkg_check_modules(PC_JSONCPP jsoncpp QUIET)
 endif()
 
-if(NOT JSONCPP_FOUND)
-  find_path(JSONCPP_INCLUDE_DIRS json/json.h
-            PATH_SUFFIXES jsoncpp)
-  find_library(JSONCPP_LIBRARIES jsoncpp)
-endif()
+find_path(JSONCPP_INCLUDE_DIRS json/json.h
+                               PATHS ${PC_JSONCPP_INCLUDEDIR}
+                               PATH_SUFFIXES jsoncpp)
+find_library(JSONCPP_LIBRARIES jsoncpp
+                               PATHS ${PC_JSONCPP_LIBDIR})
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(JsonCpp DEFAULT_MSG JSONCPP_LIBRARIES JSONCPP_INCLUDE_DIRS)
+find_package_handle_standard_args(JsonCpp REQUIRED_VARS JSONCPP_LIBRARIES JSONCPP_INCLUDE_DIRS)
 
 mark_as_advanced(JSONCPP_INCLUDE_DIRS JSONCPP_LIBRARIES)

--- a/depends/common/jsoncpp/CMakeLists.txt
+++ b/depends/common/jsoncpp/CMakeLists.txt
@@ -1,7 +1,6 @@
+cmake_minimum_required(VERSION 3.5)
 project(jsoncpp)
 
-cmake_minimum_required(VERSION 3.1)
-enable_language(CXX)
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)

--- a/pvr.sledovanitv.cz/addon.xml.in
+++ b/pvr.sledovanitv.cz/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.sledovanitv.cz"
-  version="1.5.0"
+  version="1.5.1"
   name="PVR Client for sledovanitv.cz (unofficial)"
   provider-name="palinek">
   <requires>@ADDON_DEPENDS@</requires>

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -27,7 +27,7 @@
 #include "client.h"
 
 #include "PVRIptvData.h"
-#include "xbmc_pvr_dll.h"
+#include "kodi/xbmc_pvr_dll.h"
 
 #include <iostream>
 #include <atomic>

--- a/src/client.h
+++ b/src/client.h
@@ -25,8 +25,8 @@
  *
  */
 
-#include "libXBMC_addon.h"
-#include "libXBMC_pvr.h"
+#include "kodi/libXBMC_addon.h"
+#include "kodi/libXBMC_pvr.h"
 #include <memory>
 
 extern std::unique_ptr<ADDON::CHelper_libXBMC_addon> XBMC;


### PR DESCRIPTION
This is related to xbmc/xbmc#16458

Also is a package check fix included, with before can be problematic if OS include itself and also present on Kodi's build. Further is a .gitignore added to prevent wrongly with `git add .` brought files :smile: 