### PR TITLE
[Matrix] API change updates

### DIFF
--- a/pvr.sledovanitv.cz/addon.xml.in
+++ b/pvr.sledovanitv.cz/addon.xml.in
@@ -4,7 +4,9 @@
   version="2.5.1"
   name="PVR Client for sledovanitv.cz (unofficial)"
   provider-name="palinek">
-  <requires>@ADDON_DEPENDS@</requires>
+  <requires>@ADDON_DEPENDS@
+    <import addon="inputstream.adaptive" minversion="2.5.5" optional="true"/>
+  </requires>
   <extension
     point="xbmc.pvrclient"
     library_@PLATFORM@="@LIBRARY_FILENAME@"/>

--- a/pvr.sledovanitv.cz/addon.xml.in
+++ b/pvr.sledovanitv.cz/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.sledovanitv.cz"
-  version="2.5.1"
+  version="2.5.2"
   name="PVR Client for sledovanitv.cz (unofficial)"
   provider-name="palinek">
   <requires>@ADDON_DEPENDS@

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -188,7 +188,7 @@ ADDON_STATUS ADDON_Create(void* hdl, void* props)
     return ADDON_STATUS_UNKNOWN;
   }
 
-  PVR_PROPERTIES* pvrprops = (PVR_PROPERTIES*)props;
+  AddonProperties_PVR* pvrprops = (AddonProperties_PVR*)props;
 
   XBMC.reset(new CHelper_libXBMC_addon);
   if (!XBMC->RegisterMe(hdl))

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -419,10 +419,10 @@ PVR_ERROR GetChannelGroupMembers(ADDON_HANDLE handle, const PVR_CHANNEL_GROUP &g
   return PVR_ERROR_SERVER_ERROR;
 }
 
-PVR_ERROR SignalStatus(PVR_SIGNAL_STATUS &signalStatus)
+PVR_ERROR GetSignalStatus(int channelUid, PVR_SIGNAL_STATUS *signalStatus)
 {
-  snprintf(signalStatus.strAdapterName, sizeof(signalStatus.strAdapterName), "sledovanitv.cz");
-  snprintf(signalStatus.strAdapterStatus, sizeof(signalStatus.strAdapterStatus), "OK");
+  snprintf(signalStatus->strAdapterName, sizeof(signalStatus->strAdapterName), "sledovanitv.cz");
+  snprintf(signalStatus->strAdapterStatus, sizeof(signalStatus->strAdapterStatus), "OK");
 
   return PVR_ERROR_NO_ERROR;
 }
@@ -645,7 +645,7 @@ void OnSystemSleep() { }
 void OnSystemWake() { }
 void OnPowerSavingActivated() { }
 void OnPowerSavingDeactivated() { }
-PVR_ERROR GetDescrambleInfo(PVR_DESCRAMBLE_INFO*) { return PVR_ERROR_NOT_IMPLEMENTED; }
+PVR_ERROR GetDescrambleInfo(int, PVR_DESCRAMBLE_INFO*) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR SetRecordingLifetime(const PVR_RECORDING*) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR GetStreamProperties(PVR_STREAM_PROPERTIES*) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR GetStreamTimes(PVR_STREAM_TIMES*) { return PVR_ERROR_NOT_IMPLEMENTED; }

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -258,7 +258,7 @@ void ADDON_Announce(const char *flag, const char *sender, const char *message, c
 /***********************************************************
  * PVR Client AddOn specific public library functions
  ***********************************************************/
-PVR_ERROR GetAddonCapabilities(PVR_ADDON_CAPABILITIES* pCapabilities)
+PVR_ERROR GetCapabilities(PVR_ADDON_CAPABILITIES* pCapabilities)
 {
   XBMC->Log(LOG_DEBUG, "%s", __FUNCTION__);
   pCapabilities->bSupportsEPG             = true;


### PR DESCRIPTION
Related to xbmc/xbmc#17775 and to bring in after them.

Only startup and dll load test confirmed and OK, but with no access to sledovanitv.cz not runtime tested.

This changes are mostly to prepare on Kodi itself for the coming rework to C++ PVR interface and to reduce his change size there.

Further and primary thought do fix part reported here https://github.com/xbmc/xbmc/pull/17764 where his commit included in my Kodi request.

Seen this use also inputstream.adaptive and added then in addon.xml as optional depend, so if available it becomes from user installed too.

Question about this addon. I create a chart where all pvr addons in a table and to see what is different to others. So that a user can see within one page what are the difference between the much PVR addons on Kodi.
Like here I see:
- Internet stream (other addons, e.g. have own Hardware backend or own Software backend)
- Need account (that related website need user / password)
- Allow timers and recordings
- Allow HD streams
- Optional depend addon "inputstream.adaptive"

As Questions:
- Does it only allow access from **"CZ"** or from everywhere on world?
- Seen on his website by "Sign Up" nothing about money, must be this payed or is it free?
