### PR TITLE
Fully implement IsRealTimeStream()

### DIFF
--- a/pvr.sledovanitv.cz/addon.xml.in
+++ b/pvr.sledovanitv.cz/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.sledovanitv.cz"
-  version="2.5.2"
+  version="2.5.3"
   name="PVR Client for sledovanitv.cz (unofficial)"
   provider-name="palinek">
   <requires>@ADDON_DEPENDS@

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -47,6 +47,7 @@ using namespace ADDON;
 
 ADDON_STATUS   m_CurStatus      = ADDON_STATUS_UNKNOWN;
 static std::shared_ptr<sledovanitvcz::Data> m_data;
+bool m_bLivePlayback = false;
 
 /* User adjustable settings are saved here.
  * Default values are defined inside client.h
@@ -357,7 +358,9 @@ PVR_ERROR GetEPGTagStreamProperties(const EPG_TAG* tag, PVR_NAMED_VALUE* propert
   if (PVR_ERROR_NO_ERROR != ret)
     return ret;
 
-  return FillStreamProperties(data->GetStreamProperties(stream_url, stream_type, false), properties, iPropertiesCount);
+  m_bLivePlayback = false;
+
+  return FillStreamProperties(data->GetStreamProperties(stream_url, stream_type, m_bLivePlayback), properties, iPropertiesCount);
 }
 
 int GetChannelsAmount(void)
@@ -389,7 +392,9 @@ PVR_ERROR GetChannelStreamProperties(const PVR_CHANNEL* channel, PVR_NAMED_VALUE
   if (PVR_ERROR_NO_ERROR != ret)
     return ret;
 
-  return FillStreamProperties(data->GetStreamProperties(stream_url, stream_type, true), properties, iPropertiesCount);
+  m_bLivePlayback = true;
+
+  return FillStreamProperties(data->GetStreamProperties(stream_url, stream_type, m_bLivePlayback), properties, iPropertiesCount);
 }
 
 int GetChannelGroupsAmount(void)
@@ -464,7 +469,9 @@ PVR_ERROR GetRecordingStreamProperties(const PVR_RECORDING* recording, PVR_NAMED
   if (PVR_ERROR_NO_ERROR != ret)
     return ret;
 
-  return FillStreamProperties(data->GetStreamProperties(stream_url, stream_type, false), properties, iPropertiesCount);
+  m_bLivePlayback = false;
+
+  return FillStreamProperties(data->GetStreamProperties(stream_url, stream_type, m_bLivePlayback), properties, iPropertiesCount);
 }
 
 /** TIMER FUNCTIONS */
@@ -596,7 +603,7 @@ bool CanPauseStream(void)
 
 bool IsRealTimeStream()
 {
-  return true;
+  return m_bLivePlayback;
 }
 
 const char *GetBackendHostname(void)


### PR DESCRIPTION
v2.5.3
- Fully implement IsRealTimeStream()

Can be merged once you are happy with the change and CI passes.

The change is related to a change in kodi whereby this function can be called when playing back a recording. If not correctly set the fast forward/rewind buttons can be missing.