### PR TITLE
GitHub Actions: Debian build job: switch actions runner from ubuntu-18.04 to ubuntu-latest

### DIFF
--- a/.github/build.yml
+++ b/.github/build.yml
@@ -11,14 +11,14 @@ jobs:
       matrix:
         include:
         - name: "Debian package test"
-          os: ubuntu-18.04
+          os: ubuntu-latest
           CC: gcc
           CXX: g++
           DEBIAN_BUILD: true
-        - os: ubuntu-18.04
+        - os: ubuntu-latest
           CC: gcc
           CXX: g++
-        - os: ubuntu-18.04
+        - os: ubuntu-latest
           CC: clang
           CXX: clang++
         - os: macos-10.15
@@ -36,7 +36,7 @@ jobs:
         repository: xbmc/xbmc
         ref: master
         path: xbmc
-    - name: Checkout pvr.sledovanitv.cz repo
+    - name: Checkout add-on repo
       uses: actions/checkout@v2
       with:
         path: ${{ env.app_id }}


### PR DESCRIPTION
GitHub Actions: ubuntu-18.04 runner is eol. https://github.com/actions/runner-images/issues/6002