### PR TITLE
Set inputstream.adaptive live_delay property

### DIFF
--- a/src/Data.cpp
+++ b/src/Data.cpp
@@ -1413,6 +1413,7 @@ std::vector<kodi::addon::PVRStreamProperty> Data::StreamProperties(const std::st
   if (m_useAdaptive && 0 < ADAPTIVE_TYPES.count(streamType))
   {
     properties.emplace_back(PVR_STREAM_PROPERTY_INPUTSTREAM, "inputstream.adaptive");
+    properties.emplace_back("inputstream.adaptive.live_delay", "30");
     if (isDrm)
     {
       decltype (m_drmCertificate) certificate;


### PR DESCRIPTION
When the addon is configured to use inputstream.adaptive, the playback is not as smooth as when it's disabled. It seems kodi is trying to play the stream too close to the live edge, which occasionally causes buffering and high CPU load.

The delay can be configured by the `live_delay` property. The default is 16 seconds. This patch increases the delay to 30 seconds as recommended in the inputstream.adaptive documentation to be 2-4x of the segment length. That completely fixes the problem for me.

Please note that the `inputstream.adaptive.live_delay` is marked as deprecated in Piers. It seems the new way would be to set `inputstream.adaptive.manifest_config` to `{"live_delay":30}`, but I didn't test that. I can make a separate PR for Piers if interested.